### PR TITLE
Fixed translation string

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Where `username` is the user's GitHub username, and `contribution` is a `,`-sepa
   - tool: 🔧
   - infra: 🚇
   - doc: 📖
-  - translate: 🌍
+  - translation: 🌍
   - question: 💬
   - test: ⚠️
   - bug: 🐛


### PR DESCRIPTION
Updating the README to reflect the correct symbol for the `translation` contribution. (Using `translate` returns `Cannot read property 'symbol' of undefined` when you run `all-contributors generate`.)