### PR TITLE
Support pipe characters in github names

### DIFF
--- a/lib/generate/fixtures/contributors.json
+++ b/lib/generate/fixtures/contributors.json
@@ -18,5 +18,14 @@
     "contributions": [
       "review"
     ]
+  },
+  "pipey": {
+    "login": "pipey",
+    "name": "Who | Needs | Pipes?",
+    "profile": "http://github.com/chrisinajar",
+    "avatar_url": "https://avatars1.githubusercontent.com/u/1500684",
+    "contributions": [
+      "doc"
+    ]
   }
 }

--- a/lib/generate/format-contributor.js
+++ b/lib/generate/format-contributor.js
@@ -4,15 +4,23 @@ var _ = require('lodash/fp');
 var formatContributionType = require('./format-contribution-type');
 
 var avatarTemplate = _.template('<img src="<%= contributor.avatar_url %>" width="<%= options.imageSize %>px;"/>');
-var avatarBlockTemplate = _.template('[<%= avatar %><br /><sub><%= contributor.name %></sub>](<%= contributor.profile %>)');
+var avatarBlockTemplate = _.template('[<%= avatar %><br /><sub><%= name %></sub>](<%= contributor.profile %>)');
 var contributorTemplate = _.template('<%= avatarBlock %><br /><%= contributions %>');
 
 var defaultImageSize = 100;
 
 function defaultTemplate(templateData) {
   var avatar = avatarTemplate(templateData);
-  var avatarBlock = avatarBlockTemplate(_.assign({avatar: avatar}, templateData));
+  var avatarBlock = avatarBlockTemplate(_.assign({
+    name: escapeName(templateData.contributor.name),
+    avatar: avatar
+  }, templateData));
+
   return contributorTemplate(_.assign({avatarBlock: avatarBlock}, templateData));
+}
+
+function escapeName(name) {
+  return name.replace(new RegExp('\\|', 'g'), '&#124;');
 }
 
 module.exports = function formatContributor(options, contributor) {

--- a/lib/generate/format-contributor.test.js
+++ b/lib/generate/format-contributor.test.js
@@ -49,3 +49,12 @@ test('should default image size to 100', t => {
 
   t.is(formatContributor(options, contributor), expected);
 });
+
+test('should format contributor with pipes in their name', t => {
+  const contributor = contributors.pipey;
+  const {options} = fixtures();
+
+  const expected = '[<img src="https://avatars1.githubusercontent.com/u/1500684" width="150px;"/><br /><sub>Who &#124; Needs &#124; Pipes?</sub>](http://github.com/chrisinajar)<br />[📖](https://github.com/jfmengels/all-contributors-cli/commits?author=pipey)';
+
+  t.is(formatContributor(options, contributor), expected);
+});


### PR DESCRIPTION
Since generate creates a table, pipe characters in names break everything. This change will make it replace all the pipe characters with `&#124;` in just the name part of the template. Added test case as well.