### PR TITLE
docs: add alt text to symbols in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,25 +54,25 @@ all-contributors add <username> <contribution>
 all-contributors add jfmengels code,doc
 ```
 Where `username` is the user's GitHub username, and `contribution` is a `,`-separated list of ways to contribute, from the following list ([see the specs](https://github.com/kentcdodds/all-contributors#emoji-key)):
-  - code: 💻
-  - plugin: 🔌
-  - tool: 🔧
-  - infra: 🚇
-  - doc: 📖
-  - translation: 🌍
-  - question: 💬
-  - test: ⚠️
-  - bug: 🐛
-  - example: 💡
-  - blog: 📝
-  - tutorial: ✅
-  - video: 📹
-  - talk: 📢
-  - design: 🎨
-  - review: 👀
-  - financial: 💵
-  - fundingFinding: 🔍
-  - eventOrganizing: 📋
+  - code: [💻](# "Code")
+  - plugin: [🔌](# "Plugin/utility libraries")
+  - tool: [🔧](# "Tools")
+  - infra: [🚇](# "Infrastructure (Hosting, Build-Tools, etc)")
+  - doc: [📖](# "Documentation")
+  - translation: [🌍](# "Translation")
+  - question: [💬](# "Answering Questions")
+  - test: [⚠️](# "Tests")
+  - bug: [🐛](# "Bug reports")
+  - example: [💡](# "Examples")
+  - blog: [📝](# "Blogposts")
+  - tutorial: [✅](# "Tutorials")
+  - video: [📹](# "Videos")
+  - talk: [📢](# "Talks")
+  - design: [🎨](# "Design")
+  - review: [👀](# "Reviewed Pull Requests")
+  - financial: [💵](# "Financial")
+  - fundingFinding: [🔍](# "Funding Finding")
+  - eventOrganizing: [📋](# "Event Organizing")
 
 ## Configuration
 


### PR DESCRIPTION
Now that we know how to have alt-text on the emojis, we might as well have them on all the ones we show, for consistency and to make stuff clearer.
I do wonder whether we should not simply also add the same text next to the emoji. What do you think?

(By the way, sorry for my lack of presence the last months :disappointed:)