### PR TITLE
Github returns 200s for specific errors.

### DIFF
--- a/lib/contributors/github.js
+++ b/lib/contributors/github.js
@@ -12,13 +12,13 @@ module.exports = function getUserInfo(username) {
   })
   .then(res => {
     var body = JSON.parse(res.body);
+    var profile = body.blog || body.html_url;
 
     // Github throwing specific errors as 200...
-    if (body.message) {
+    if (!profile && body.message) {
       throw new Error(body.message);
     }
 
-    var profile = body.blog || body.html_url;
     profile = profile.startsWith('http') ? profile : 'http://' + profile;
 
     return {

--- a/lib/contributors/github.js
+++ b/lib/contributors/github.js
@@ -12,6 +12,12 @@ module.exports = function getUserInfo(username) {
   })
   .then(res => {
     var body = JSON.parse(res.body);
+
+    // Github throwing specific errors as 200...
+    if (body.message) {
+      throw new Error(body.message);
+    }
+
     var profile = body.blog || body.html_url;
     profile = profile.startsWith('http') ? profile : 'http://' + profile;
 

--- a/lib/contributors/github.test.js
+++ b/lib/contributors/github.test.js
@@ -10,6 +10,17 @@ test('should handle errors', t => {
   return t.throws(getUserInfo('nodisplayname'));
 });
 
+test('should handle github errors', t => {
+  nock('https://api.github.com')
+    .get('/users/nodisplayname')
+    .reply(200, {
+      message: 'API rate limit exceeded for 0.0.0.0. (But here\'s the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)',
+      documentation_url: 'https://developer.github.com/v3/#rate-limiting'
+    });
+
+  return t.throws(getUserInfo('nodisplayname'));
+});
+
 test('should fill in the name when null is returned', t => {
   nock('https://api.github.com')
     .get('/users/nodisplayname')


### PR DESCRIPTION
Added exception handling when github returns 200 even though the call has been rate-limited. This is the only error I've encountered (just happened to me from work while using this), but there may be others.