### PR TITLE
doc: change suggested scripts names

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,6 @@ Once initialized, you don't need to have  `all-contributors-cli` installed globa
 ```console
 npm install --save-dev all-contributors-cli
 ```
-```console
-yarn add all-contributors-cli --dev
-```
 
 ```json
 {
@@ -35,12 +32,6 @@ and use them via `npm run`:
 ```console
 npm run append -- jfmengels doc
 npm run generate
-```
-
-OR use them via `yarn`:
-```console
-yarn append jfmengels doc
-yarn generate
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -23,15 +23,15 @@ npm install --save-dev all-contributors-cli
 ```json
 {
   "scripts": {
-    "append": "all-contributors add",
-    "generate": "all-contributors generate"
+    "contributors:add": "all-contributors add",
+    "contributors:generate": "all-contributors generate"
   }
 }
 ```
 and use them via `npm run`:
 ```console
-npm run append -- jfmengels doc
-npm run generate
+npm run contributors:add -- jfmengels doc
+npm run contributors:generate
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -19,18 +19,28 @@ Once initialized, you don't need to have  `all-contributors-cli` installed globa
 ```console
 npm install --save-dev all-contributors-cli
 ```
+```console
+yarn add all-contributors-cli --dev
+```
+
 ```json
 {
   "scripts": {
-    "add": "all-contributors add",
+    "append": "all-contributors add",
     "generate": "all-contributors generate"
   }
 }
 ```
 and use them via `npm run`:
 ```console
-npm run add -- jfmengels doc
+npm run append -- jfmengels doc
 npm run generate
+```
+
+OR use them via `yarn`:
+```console
+yarn append jfmengels doc
+yarn generate
 ```
 
 ## Usage


### PR DESCRIPTION
The script name suggested (`add`) will conflict with users of yarn.

So I modified the suggested name to `append` and provided a yarn example as well.