### PR TITLE
fix: make find/add case insensitive

### DIFF
--- a/lib/contributors/add.js
+++ b/lib/contributors/add.js
@@ -23,7 +23,7 @@ function updateContributor(options, contributor, contributions) {
 
 function updateExistingContributor(options, username, contributions) {
   return options.contributors.map(function (contributor) {
-    if (username !== contributor.login) {
+    if (username.toLowerCase() !== contributor.login.toLowerCase()) {
       return contributor;
     }
     return updateContributor(options, contributor, contributions);
@@ -41,8 +41,14 @@ function addNewContributor(options, username, contributions, infoFetcher) {
 }
 
 module.exports = function addContributor(options, username, contributions, infoFetcher) {
-  if (_.find({login: username}, options.contributors)) {
+  // case insensitive find
+  var exists = _.find(function(contributor) {
+    return contributor.login.toLowerCase() === username.toLowerCase()
+  }, options.contributors)
+
+  if (exists) {
     return Promise.resolve(updateExistingContributor(options, username, contributions));
   }
   return addNewContributor(options, username, contributions, infoFetcher);
 };
+

--- a/lib/contributors/add.js
+++ b/lib/contributors/add.js
@@ -42,9 +42,9 @@ function addNewContributor(options, username, contributions, infoFetcher) {
 
 module.exports = function addContributor(options, username, contributions, infoFetcher) {
   // case insensitive find
-  var exists = _.find(function(contributor) {
-    return contributor.login.toLowerCase() === username.toLowerCase()
-  }, options.contributors)
+  var exists = _.find(function (contributor) {
+    return contributor.login.toLowerCase() === username.toLowerCase();
+  }, options.contributors);
 
   if (exists) {
     return Promise.resolve(updateExistingContributor(options, username, contributions));

--- a/lib/contributors/add.test.js
+++ b/lib/contributors/add.test.js
@@ -34,6 +34,21 @@ function fixtures() {
   return {options};
 }
 
+function caseFixtures() {
+  const options = {
+    contributors: [{
+      login: 'Login1',
+      name: 'Some name',
+      avatar_url: 'www.avatar.url',
+      profile: 'www.profile.url',
+      contributions: [
+        'code'
+      ]
+    }]
+  };
+  return {options};
+}
+
 test('should callback with error if infoFetcher fails', t => {
   const {options} = fixtures();
   const username = 'login3';
@@ -100,6 +115,17 @@ test(`should not update an existing contributor's contributions where nothing ha
   });
 });
 
+test(`should not update an existing contributor's contributions where nothing has changed but the casing`, t => {
+  const {options} = caseFixtures();
+  const username = 'login1';
+  const contributions = ['code'];
+
+  return addContributor(options, username, contributions, mockInfoFetcher)
+  .then(contributors => {
+    t.deepEqual(contributors, options.contributors);
+  });
+});
+
 test(`should update an existing contributor's contributions if a new type is added`, t => {
   const {options} = fixtures();
   const username = 'login1';
@@ -109,6 +135,26 @@ test(`should update an existing contributor's contributions if a new type is add
     t.is(contributors.length, 2);
     t.deepEqual(contributors[0], {
       login: 'login1',
+      name: 'Some name',
+      avatar_url: 'www.avatar.url',
+      profile: 'www.profile.url',
+      contributions: [
+        'code',
+        'bug'
+      ]
+    });
+  });
+});
+
+test(`should update an existing contributor's contributions if a new type is added with different username case`, t => {
+  const {options} = caseFixtures();
+  const username = 'login1';
+  const contributions = ['bug'];
+  return addContributor(options, username, contributions, mockInfoFetcher)
+  .then(contributors => {
+    t.is(contributors.length, 1);
+    t.deepEqual(contributors[0], {
+      login: 'Login1',
       name: 'Some name',
       avatar_url: 'www.avatar.url',
       profile: 'www.profile.url',


### PR DESCRIPTION
I would type:
`all-contributors add gantman blog` 
and it would get `GantMan` from github.  This caused it to duplicate my user entry over and over.  Making both the find and the update case-insensitive fixes this.  Adding 2 tests as well.

closes #62 