### PR TITLE
Support contributors without github accounts

### DIFF
--- a/src/contributors/__tests__/add.js
+++ b/src/contributors/__tests__/add.js
@@ -26,6 +26,12 @@ function fixtures() {
         profile: 'www.profile.url',
         contributions: [{type: 'blog', url: 'www.blog.url/path'}, 'code'],
       },
+      {
+        name: 'Missing Login',
+        avatar_url: 'www.avatar.url',
+        profile: 'www.profile.url',
+        contributions: ['code'],
+      },
     ],
   }
   return {options}
@@ -71,8 +77,8 @@ test('add new contributor at the end of the list of contributors', () => {
 
   return addContributor(options, username, contributions, mockInfoFetcher).then(
     contributors => {
-      expect(contributors.length).toBe(3)
-      expect(contributors[2]).toEqual({
+      expect(contributors.length).toBe(options.contributors.length + 1)
+      expect(contributors[options.contributors.length]).toEqual({
         login: 'login3',
         name: 'Some name',
         avatar_url: 'www.avatar.url',
@@ -91,8 +97,8 @@ test('add new contributor at the end of the list of contributors with a url link
 
   return addContributor(options, username, contributions, mockInfoFetcher).then(
     contributors => {
-      expect(contributors.length).toBe(3)
-      expect(contributors[2]).toEqual({
+      expect(contributors.length).toBe(options.contributors.length + 1)
+      expect(contributors[options.contributors.length]).toEqual({
         login: 'login3',
         name: 'Some name',
         avatar_url: 'www.avatar.url',
@@ -133,7 +139,7 @@ test(`should update an existing contributor's contributions if a new type is add
   const contributions = ['bug']
   return addContributor(options, username, contributions, mockInfoFetcher).then(
     contributors => {
-      expect(contributors.length).toBe(2)
+      expect(contributors.length).toBe(options.contributors.length)
       expect(contributors[0]).toEqual({
         login: 'login1',
         name: 'Some name',
@@ -171,7 +177,7 @@ test(`should update an existing contributor's contributions if a new type is add
 
   return addContributor(options, username, contributions, mockInfoFetcher).then(
     contributors => {
-      expect(contributors.length).toBe(2)
+      expect(contributors.length).toBe(options.contributors.length)
       expect(contributors[0]).toEqual({
         login: 'login1',
         name: 'Some name',

--- a/src/contributors/add.js
+++ b/src/contributors/add.js
@@ -27,7 +27,10 @@ function updateContributor(options, contributor, contributions) {
 
 function updateExistingContributor(options, username, contributions) {
   return options.contributors.map(contributor => {
-    if (username.toLowerCase() !== contributor.login.toLowerCase()) {
+    if (
+      !contributor.login ||
+      username.toLowerCase() !== contributor.login.toLowerCase()
+    ) {
       return contributor
     }
     return updateContributor(options, contributor, contributions)
@@ -51,7 +54,10 @@ module.exports = function addContributor(
 ) {
   // case insensitive find
   const exists = _.find(contributor => {
-    return contributor.login.toLowerCase() === username.toLowerCase()
+    return (
+      contributor.login &&
+      contributor.login.toLowerCase() === username.toLowerCase()
+    )
   }, options.contributors)
 
   if (exists) {

--- a/src/contributors/prompt.js
+++ b/src/contributors/prompt.js
@@ -35,6 +35,7 @@ function getQuestions(options, username, contributions) {
         return options.contributors
           .filter(
             entry =>
+              entry.login &&
               entry.login.toLowerCase() === answers.username.toLowerCase(),
           )
           .reduce(
@@ -48,6 +49,7 @@ function getQuestions(options, username, contributions) {
         const previousContributions = options.contributors
           .filter(
             entry =>
+              entry.login &&
               entry.login.toLowerCase() === answers.username.toLowerCase(),
           )
           .reduce(

--- a/src/generate/__tests__/fixtures/contributors.json
+++ b/src/generate/__tests__/fixtures/contributors.json
@@ -19,5 +19,15 @@
     "profile": "http://github.com/chrisinajar",
     "avatar_url": "https://avatars1.githubusercontent.com/u/1500684",
     "contributions": ["doc"]
+  },
+  "nologin": {
+    "name": "No Github Account",
+    "avatar_url": "https://avatars1.githubusercontent.com/u/1500684",
+    "contributions": ["translation"]
+  },
+  "nologin_badrole": {
+    "name": "Wildly Misconfigured",
+    "avatar_url": "https://avatars1.githubusercontent.com/u/1500684",
+    "contributions": ["plumbis"]
   }
 }

--- a/src/generate/__tests__/format-contribution-type.js
+++ b/src/generate/__tests__/format-contribution-type.js
@@ -153,3 +153,13 @@ test('throw a helpful error on unknown type', () => {
     formatContributionType(options, contributor, 'docs'),
   ).toThrowError('Unknown contribution type docs for contributor kentcdodds')
 })
+
+test('throw a helpful error on unknown type and no login', () => {
+  const contributor = contributors.nologin_badrole
+  const {options} = fixtures()
+  expect(() =>
+    formatContributionType(options, contributor, 'docs'),
+  ).toThrowError(
+    'Unknown contribution type docs for contributor Wildly Misconfigured',
+  )
+})

--- a/src/generate/__tests__/format-contributor.js
+++ b/src/generate/__tests__/format-contributor.js
@@ -65,3 +65,13 @@ test('format contributor with pipes in their name', () => {
 
   expect(formatContributor(options, contributor)).toBe(expected)
 })
+
+test('format contributor with no github account', () => {
+  const contributor = contributors.nologin
+  const {options} = fixtures()
+
+  const expected =
+    '<img src="https://avatars1.githubusercontent.com/u/1500684" width="150px;"/><br /><sub><b>No Github Account</b></sub><br />[🌍](#translation "Translation")'
+
+  expect(formatContributor(options, contributor)).toBe(expected)
+})

--- a/src/generate/format-contribution-type.js
+++ b/src/generate/format-contribution-type.js
@@ -19,9 +19,8 @@ module.exports = function formatContribution(
 
   if (!type) {
     throw new Error(
-      `Unknown contribution type ${contribution} for contributor ${
-        contributor.login
-      }`,
+      `Unknown contribution type ${contribution} for contributor ${contributor.login ||
+        contributor.name}`,
     )
   }
 
@@ -32,7 +31,8 @@ module.exports = function formatContribution(
     options,
   }
 
-  let url = `#${contribution}-${contributor.login}`
+  let url = getUrl(contribution, contributor)
+
   if (contribution.url) {
     url = contribution.url
   } else if (type.link) {
@@ -40,4 +40,12 @@ module.exports = function formatContribution(
   }
 
   return linkTemplate(_.assign({url}, templateData))
+}
+
+function getUrl(contribution, contributor) {
+  if (contributor.login) {
+    return `#${contribution}-${contributor.login}`
+  } else {
+    return `#${contribution}`
+  }
 }

--- a/src/generate/format-contributor.js
+++ b/src/generate/format-contributor.js
@@ -7,6 +7,9 @@ const avatarTemplate = _.template(
 const avatarBlockTemplate = _.template(
   '[<%= avatar %><br /><sub><b><%= name %></b></sub>](<%= contributor.profile %>)',
 )
+const avatarBlockTemplateNoProfile = _.template(
+  '<%= avatar %><br /><sub><b><%= name %></b></sub>',
+)
 const contributorTemplate = _.template(
   '<%= avatarBlock %><br /><%= contributions %>',
 )
@@ -15,15 +18,20 @@ const defaultImageSize = 100
 
 function defaultTemplate(templateData) {
   const avatar = avatarTemplate(templateData)
-  const avatarBlock = avatarBlockTemplate(
-    _.assign(
-      {
-        name: escapeName(templateData.contributor.name),
-        avatar,
-      },
-      templateData,
-    ),
+  const avatarBlockTemplateData = _.assign(
+    {
+      name: escapeName(templateData.contributor.name),
+      avatar,
+    },
+    templateData,
   )
+  let avatarBlock = null
+
+  if (templateData.contributor.profile) {
+    avatarBlock = avatarBlockTemplate(avatarBlockTemplateData)
+  } else {
+    avatarBlock = avatarBlockTemplateNoProfile(avatarBlockTemplateData)
+  }
 
   return contributorTemplate(_.assign({avatarBlock}, templateData))
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Fix regression in which if you have any user already added who does not have a github account then the command line fails without any useful error messages.

<!-- Why are these changes necessary? -->
**Why**: The spirit of all-contributors is such that _all_ contributors get credit, not just those who are github savvy.

<!-- How were these changes implemented? -->
**How**: Test driven development

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation -- N/A
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
NOTE: This situation only arrises when you have manually added non-github users into your `.all-contributorsrc` file. This used to work but regressed in recent versions.