### PR TITLE
fix: surface the message when the check api returns an error

### DIFF
--- a/src/util/check.js
+++ b/src/util/check.js
@@ -25,7 +25,7 @@ function getContributorsPage(url) {
     })
     .then(res => {
       const body = JSON.parse(res.body)
-      if (res.statusCode !== 200) {
+      if (res.statusCode >= 400) {
         throw new Error(body.message)
       }
       const contributorsIds = body.map(contributor => contributor.login)

--- a/src/util/check.js
+++ b/src/util/check.js
@@ -25,6 +25,9 @@ function getContributorsPage(url) {
     })
     .then(res => {
       const body = JSON.parse(res.body)
+      if (res.statusCode !== 200) {
+        throw new Error(body.message)
+      }
       const contributorsIds = body.map(contributor => contributor.login)
 
       const nextLink = getNextLink(res.headers.link)
@@ -39,8 +42,6 @@ function getContributorsPage(url) {
 }
 
 module.exports = function getContributorsFromGithub(owner, name) {
-  const url = `https://api.github.com/repos/${owner}/${
-    name
-  }/contributors?per_page=100`
+  const url = `https://api.github.com/repos/${owner}/${name}/contributors?per_page=100`
   return getContributorsPage(url)
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
If the contributors API returns a bad response show the error message

<!-- Why are these changes necessary? -->
**Why**:
I ran into this when I was running the check command. The CLI was throwing an error on this line https://github.com/jfmengels/all-contributors-cli/blob/master/src/util/check.js#L28 the response from the API was a 403 and I was getting rate limited. The response was something like
```
{ "message": "API rate limit exceeded" }
```
but there's no prior check to see if either the response is a 200 or if the body is an array. I think it makes sense to throw an error and tell the user what's happening.

<!-- How were these changes implemented? -->
**How**:
Updated the code to throw an error if the API response isn't 200.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
