### PR TITLE
fix: output error messages if git commands failed

### DIFF
--- a/src/util/git.js
+++ b/src/util/git.js
@@ -37,8 +37,16 @@ function getRepoInfo() {
 
 const spawnGitCommand = pify((args, cb) => {
   const git = spawn('git', args)
-  git.stderr.on('data', cb)
-  git.on('close', cb)
+  const bufs = [];
+  git.stderr.on('data', (buf) => bufs.push(buf));
+  git.on('close', (code) => {
+    if (code) {
+      const msg = Buffer.concat(bufs).toString() || `git ${args.join('')} - exit code: ${code}`;
+      cb(new Error(msg));
+    } else {
+      cb(null);
+    }
+  });
 })
 
 function commit(options, data) {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:

Fixes #48.

<!-- Why are these changes necessary? -->
**Why**:

The current usage of `cb` is not very suitable. It expects `(err, ret)`, but `buf/code` is sent as `err`, which results in [`error.message`](https://github.com/jfmengels/all-contributors-cli/blob/master/src/cli.js#L124) to be `undefined`.

```
- git.stderr.on('data', cb)
- git.on('close', cb)
+ git.stderr.on('data', (buf) => {});
+ git.on('close', (code) => {})
```

<!-- How were these changes implemented? -->
**How**:

Collect all error messages and return.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
