### PR TITLE
Add clarity to CLI prompt for where repository is hosted

### DIFF
--- a/src/init/prompt.js
+++ b/src/init/prompt.js
@@ -32,7 +32,7 @@ const questions = [
   {
     type: 'input',
     name: 'repoHost',
-    message: 'Where is the repository hosted?',
+    message: 'Where is the repository hosted? Hit Enter if it\'s on GitHub or GitLab',
     default: function(answers) {
       if (answers.repoType === 'github') {
         return 'https://github.com'


### PR DESCRIPTION
Users, including myself, have put the wrong link in answer to "Where is the repository hosted?". This is a simple fix that should make it clearer what to input.

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Changes prompts in the CLI to be more specific when asking for where the repository is hosted.

<!-- Why are these changes necessary? -->
**Why**: This is necessary because users (including myself) have become confused on what to put for this. For example, I put "www.github.com/username/repository" for my use of all-contributors-cli, when it should only be the default "www.github.com".

<!-- How were these changes implemented? -->
**How**: Changes prompt to be more directional.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table N/A <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->