### PR TITLE
infra: better error handling of invalid config file

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -40,7 +40,7 @@ const yargv = yargs
     try {
       return util.configFile.readConfig(configPath)
     } catch (error) {
-      if (configPath !== defaultRCFile) {
+      if (error instanceof SyntaxError || configPath !== defaultRCFile) {
         onError(error)
       }
     }

--- a/src/util/config-file.js
+++ b/src/util/config-file.js
@@ -11,7 +11,7 @@ function readConfig(configPath) {
     return config
   } catch (error) {
     if (error instanceof SyntaxError) {
-      throw new SyntaxError(`Configuration file has malformed json: ${configPath}. Error:: ${error.message}`)
+      throw new SyntaxError(`Configuration file has malformed JSON: ${configPath}. Error:: ${error.message}`)
     }
     if (error.code === 'ENOENT') {
       throw new Error(`Configuration file not found: ${configPath}`)

--- a/src/util/config-file.js
+++ b/src/util/config-file.js
@@ -10,6 +10,9 @@ function readConfig(configPath) {
     }
     return config
   } catch (error) {
+    if (error instanceof SyntaxError) {
+      throw new SyntaxError(`Configuration file has malformed json: ${configPath}. Error:: ${error.message}`)
+    }
     if (error.code === 'ENOENT') {
       throw new Error(`Configuration file not found: ${configPath}`)
     }
@@ -24,7 +27,7 @@ function writeConfig(configPath, content) {
   if (!content.projectName) {
     throw new Error(`Error! Project name is not set in ${configPath}`)
   }
-  
+
   if (content.files && !content.files.length) {
     throw new Error(
       `Error! Project files was overridden and is empty in ${configPath}`,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
When a config file is loaded, but the contents cannot be parsed to JSON an error will be thrown. Instead of failing silent: e.g.:
<img width="735" alt="screen shot 2018-12-23 at 5 04 17 pm" src="https://user-images.githubusercontent.com/3534236/50382208-026cdb80-06d5-11e9-8f4d-8d97a9a3cbe1.png">


<!-- Why are these changes necessary? -->
**Why**:
Previously some commands would crash randomly. e.g. `add` with `Cannot read property 'then' of null`.
While other commands e.g. `generate` would succeed but would blow away all your contributors (because it didn't find any)

<!-- How were these changes implemented? -->
**How**:
By Me

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [ ] Tests  N/A
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
